### PR TITLE
PHP 7.1 and HHVM 3.17 have gone final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ php:
 matrix:
   fast_finish: true
   allow_failures:
-    - php: hhvm-3.3
-    - php: hhvm-3.6
     - php: hhvm-3.9
     - php: hhvm-3.12
+    - php: hhvm-3.15
+    - php: hhvm-3.17
     - php: hhvm-nightly
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,12 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - nightly
-  - hhvm-3.3
-  - hhvm-3.6
   - hhvm-3.9
   - hhvm-3.12
+  - hhvm-3.15
+  - hhvm-3.17
   - hhvm-nightly
 
 matrix:
@@ -43,4 +44,4 @@ after_success:
 
 notifications:
   email:
-    - 'ryan.parman@wepay.com'
+    - 'vasusen@wepay.com'


### PR DESCRIPTION
* Added PHP 7.1, HHVM 3.15, and HHVM 3.17 to the Travis CI testing matrix.
* Removed HHVM 3.3 and 3.6 from the testing matrix as they are no longer supported.
* Changed Travis CI failure contact from `ryan.parman@wepay.com` to `vasusen@wepay.com`.